### PR TITLE
v1.1

### DIFF
--- a/custom_components/bensinpriser/__init__.py
+++ b/custom_components/bensinpriser/__init__.py
@@ -8,7 +8,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    await hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bensinpriser/manifest.json
+++ b/custom_components/bensinpriser/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "bensinpriser",
   "name": "Bensinpriser",
-  "version": "1.0",
+  "version": "1.1",
   "documentation": "https://github.com/henrikhjelmse/bensinpriser",
   "issue_tracker": "https://github.com/henrikhjelmse/bensinpriser/issues",
   "dependencies": [],


### PR DESCRIPTION
- Updated the bensinpriser integration to use the new async_forward_entry_setups method instead of the deprecated async_forward_entry_setup.
- This change ensures compatibility with Home Assistant 2025.6 and prevents the integration from breaking in future updates.
- No functionality changes; this is a maintenance update to align with Home Assistant's latest API requirements.